### PR TITLE
Removing extra hash in front of commit string

### DIFF
--- a/blueprints/ember-cli-blanket/index.js
+++ b/blueprints/ember-cli-blanket/index.js
@@ -6,7 +6,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('blanket', '#5e94fc30f2e694bb5c3718ddcbf60d467f4b4d26', {saveDev: true})
+    return this.addBowerPackageToProject('blanket', '5e94fc30f2e694bb5c3718ddcbf60d467f4b4d26', {saveDev: true})
 
         // Modify tests/index.html to include the blanket options after the application
         .then(function() {


### PR DESCRIPTION
the `addBowerPackageToProject` will join the arguments with a hash. So this actually breaks the generate command because the package commit is now found.
